### PR TITLE
Fix "Too many open files" on large / fragmented genomes

### DIFF
--- a/dante_ltr
+++ b/dante_ltr
@@ -8,6 +8,7 @@ directly
 
 import argparse
 import os
+import resource
 import shutil
 import sys
 import tempfile
@@ -213,6 +214,48 @@ def make_temp_files(number_of_files):
         temp_files.append(tempfile.NamedTemporaryFile(delete=False).name)
         os.remove(temp_files[-1])
     return temp_files
+
+
+def _limit_chunks_to_fd_budget(number_of_temp_files, fd_headroom=64):
+    """Ensure the chunk split can open one handle per chunk without hitting the
+    open-file limit.
+
+    The chunk split opens all ``number_of_temp_files`` handles at once, so that
+    count must stay below ``RLIMIT_NOFILE``. This raises the soft limit toward the
+    hard limit and, if the chunk count still does not fit, returns a reduced count
+    (fewer, larger chunks) so the run degrades gracefully instead of crashing with
+    "Too many open files". ``fd_headroom`` reserves descriptors for stdio and the
+    detect_putative_ltr.R subprocess.
+
+    :param number_of_temp_files: desired number of chunk files
+    :param fd_headroom: descriptors to keep free
+    :return: a chunk count guaranteed to fit the (possibly raised) fd limit
+    """
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (ValueError, OSError):
+        return number_of_temp_files
+    want = number_of_temp_files + fd_headroom
+    if soft != resource.RLIM_INFINITY and soft < want:
+        new_soft = want if hard == resource.RLIM_INFINITY else min(hard, want)
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+            soft = new_soft
+        except (ValueError, OSError):
+            pass
+    if soft == resource.RLIM_INFINITY:
+        return number_of_temp_files
+    max_chunks = max(1, soft - fd_headroom)
+    if number_of_temp_files > max_chunks:
+        sys.stderr.write(
+            'WARNING: reducing number of chunks from {} to {} to stay within the '
+            'open-file limit ({}); chunks will be larger and use more memory. '
+            'Raise "ulimit -n" to keep smaller chunks.\n'.format(
+                number_of_temp_files, max_chunks, soft
+                )
+            )
+        return max_chunks
+    return number_of_temp_files
 
 
 def sum_up_stats_files(files):
@@ -973,6 +1016,17 @@ def main():
         number_of_temp_files = int(total_size / args.max_chunk_size) + 1
         if number_of_temp_files > number_of_sequences:
             number_of_temp_files = number_of_sequences
+
+        # The FASTA/GFF split below opens one handle per chunk *simultaneously*
+        # (see the `[open(f) for f in temp_files]` further down). number_of_temp_files
+        # grows with genome size (total_size / max_chunk_size), so on large genomes
+        # it exceeds the open-file soft limit and the split aborts with
+        # "OSError: [Errno 24] Too many open files" (e.g. ~1800 handles for a 90 Gbp
+        # genome at -S 50000000, vs a default soft limit of 1024).
+        # Fix: raise the soft limit toward the hard limit, and, only if the chunk
+        # count still cannot fit, reduce it to the available budget (fewer, larger
+        # chunks). The common case is a no-op change in chunking — just more headroom.
+        number_of_temp_files = _limit_chunks_to_fd_budget(number_of_temp_files)
 
         temp_files_fasta = make_temp_files(number_of_temp_files)
         file_handles = [open(temp_file, 'w') for temp_file in temp_files_fasta]

--- a/tests.sh
+++ b/tests.sh
@@ -40,16 +40,18 @@ case "$LEVEL" in
   short)    bash "$ROOT/tests/short.sh" ;;
   fallback) bash "$ROOT/tests/fallback.sh" ;;
   refine)   bash "$ROOT/tests/refine.sh" ;;
+  fd)       bash "$ROOT/tests/fd.sh" ;;
   long)     bash "$ROOT/tests/long.sh"  ;;
   all)
     bash "$ROOT/tests/smoke.sh"
     bash "$ROOT/tests/short.sh"
     bash "$ROOT/tests/fallback.sh"
     bash "$ROOT/tests/refine.sh"
+    bash "$ROOT/tests/fd.sh"
     bash "$ROOT/tests/long.sh"
     ;;
   *)
-    echo "usage: $0 {smoke|short|fallback|refine|long|all|<NCPU>}" >&2
+    echo "usage: $0 {smoke|short|fallback|refine|fd|long|all|<NCPU>}" >&2
     exit 2
     ;;
 esac

--- a/tests/fd.sh
+++ b/tests/fd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# tests/fd.sh — regression test for the "Too many open files" chunk-split bug.
+# The chunk split opened one handle per chunk at once; on large genomes that
+# count (total_size / max_chunk_size) exceeds ulimit -n and the run aborted with
+# OSError: [Errno 24]. Verify the fd-budget guard keeps the split within the
+# limit. Fast (<1 s), no genome needed.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+echo "=== fd budget guard (Too many open files regression) ==="
+python3 tests/test_fd_limit.py
+echo
+echo "fd PASSED"

--- a/tests/test_fd_limit.py
+++ b/tests/test_fd_limit.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Regression test for the dante_ltr "Too many open files" chunk-split bug.
+
+The chunk split (main(), the `[open(f) for f in temp_files]` loops) opens one
+file handle per chunk *simultaneously*. The number of chunks is
+`int(total_size / max_chunk_size)`, so on large genomes it exceeds the open-file
+limit and the run aborts with `OSError: [Errno 24] Too many open files`.
+
+`_limit_chunks_to_fd_budget()` must keep the chunk count within the (raised) fd
+limit so the split always fits. This test forces a low limit and checks that:
+  1. the guard caps the chunk count below the limit,
+  2. that capped number of handles can actually be opened at once, and
+  3. the original un-capped count would indeed have exhausted the fds.
+It also checks the guard is a no-op when the limit is ample.
+"""
+import importlib.machinery
+import os
+import resource
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)  # so the script's `from version import __version__` resolves
+
+
+def load_dante_ltr():
+    loader = importlib.machinery.SourceFileLoader(
+        "dante_ltr_mod", os.path.join(ROOT, "dante_ltr")
+    )
+    return loader.load_module()
+
+
+def open_all(n):
+    """Open n fresh temp files at once (the original crashing pattern)."""
+    handles, paths = [], []
+    try:
+        for _ in range(n):
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
+            paths.append(path)
+            handles.append(open(path, "w"))
+        return True
+    finally:
+        for h in handles:
+            h.close()
+        for p in paths:
+            os.remove(p)
+
+
+def run_constrained(limit):
+    # Lower BOTH soft and hard so the guard cannot raise its way out and must cap.
+    resource.setrlimit(resource.RLIMIT_NOFILE, (limit, limit))
+    mod = load_dante_ltr()
+    requested = limit * 4  # far more chunks than the fd budget
+    allowed = mod._limit_chunks_to_fd_budget(requested)
+    assert allowed < limit, f"guard did not cap: {allowed} vs limit {limit}"
+    assert open_all(allowed), "opening the capped number of handles failed"
+    crashed = False
+    try:
+        open_all(requested)
+    except OSError:
+        crashed = True
+    assert crashed, "expected the un-capped count to exhaust fds under the low limit"
+    print(f"  constrained(limit={limit}): requested {requested} -> capped {allowed}, opens OK")
+
+
+def run_ample():
+    mod = load_dante_ltr()
+    n = 50
+    allowed = mod._limit_chunks_to_fd_budget(n)
+    assert allowed == n, f"ample case changed the count: {allowed} != {n}"
+    print(f"  ample: {n} -> {allowed} (unchanged)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3 and sys.argv[1] == "--child":
+        run_constrained(int(sys.argv[2]))
+        sys.exit(0)
+    run_ample()
+    # Run the constrained case in a child so lowering the hard limit (irreversible
+    # within a process) does not affect this test runner.
+    import subprocess
+
+    subprocess.run(
+        [sys.executable, os.path.abspath(__file__), "--child", "128"], check=True
+    )
+    print("test_fd_limit: PASSED")


### PR DESCRIPTION
<!-- repo: kavonrtep/dante_ltr   base: main   head: fix/too-many-open-files -->

## Summary

On a large genome, `dante_ltr` aborts at start-up with
`OSError: [Errno 24] Too many open files`. The chunk-splitting step opens **one
temp-file handle per chunk simultaneously**, and the chunk count is
`int(total_size / max_chunk_size)`, so it grows with genome size and exceeds the
default open-file soft limit (1024) on any genome larger than ~1024 chunks — e.g.
**~1800 chunks for a 90 Gbp assembly at `-S 50000000`**. It is independent of
assembly quality (contiguous or fragmented, both trip it).

## Reproduction (observed on a ~90 Gbp genome, `-c 32 -M 1 -S 50000000`)

```
running analysis on chunks of ~ 50000000 bp
Traceback (most recent call last):
  File ".../bin/dante_ltr", line 565, in main
    file_handles = [open(temp_file, 'w') for temp_file in temp_files_fasta]
OSError: [Errno 24] Too many open files: '.../tmp/tmpXXXX'
```

## Root cause

`main()` opens every chunk handle at once, in two places (the FASTA split and the
GFF split), to distribute sequences round-robin in a single streaming pass:

```python
number_of_temp_files = int(total_size / args.max_chunk_size) + 1   # capped only by seq count
...
file_handles = [open(temp_file, 'w') for temp_file in temp_files_fasta]
```

So concurrent open handles scale linearly with genome size. The chunks are
consumed serially afterwards, and `max_chunk_size` is the per-chunk **memory**
control for `detect_putative_ltr.R`, so the chunk count can't simply be capped
without changing the memory profile the user tuned `-S` for.

## Fix

A new helper `_limit_chunks_to_fd_budget()` runs just before the split:

1. Raises the `RLIMIT_NOFILE` soft limit toward the hard limit. This alone fixes
   every case where the chunk count fits under the hard limit (typically
   4096–1048576), which covers the reported 90 Gbp run (1801 < hard).
2. Only if the chunk count still cannot fit (a very low hard limit, or a truly
   enormous genome) does it reduce the chunk count to the available budget —
   fewer, larger chunks — so the run degrades gracefully instead of crashing,
   with a warning to raise `ulimit -n`.

The common case is unchanged chunking with more fd headroom. (The sibling tool
`dante` avoids this same bug by writing with open-append; this patch keeps the
efficient single-pass write and just guarantees the fd budget.)

## Testing

- `tests/test_fd_limit.py` (+ `tests/fd.sh`, registered as the `fd` level in
  `tests.sh` and included in `all`): under a deliberately low limit it asserts the
  guard caps the chunk count within budget, that the capped number of handles can
  all be opened at once, and that the un-capped count would have exhausted the fds.
- End-to-end: reproduced the exact `line 565` crash on the released version under
  a low `ulimit`, then confirmed the patched version completes and emits a valid
  GFF3 under an even tighter limit (same input, chunked path exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)